### PR TITLE
feature/backup management tools

### DIFF
--- a/awslabs/rds_management_mcp_server/backup.py
+++ b/awslabs/rds_management_mcp_server/backup.py
@@ -1,0 +1,675 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backup management functions for RDS Management MCP Server."""
+
+import json
+import secrets
+import uuid
+from typing import Any, Dict, List, Optional
+
+from loguru import logger
+from mcp.server.fastmcp import Context
+
+from .models import (
+    AutomatedBackupModel,
+    BackupListModel,
+    SnapshotModel,
+)
+
+
+async def create_db_cluster_snapshot(
+    ctx: Context,
+    rds_client,
+    readonly: bool,
+    db_cluster_snapshot_identifier: str,
+    db_cluster_identifier: str,
+    tags: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    """Creates a manual snapshot of an RDS DB cluster.
+
+    Args:
+        ctx: MCP context
+        rds_client: Boto3 RDS client
+        readonly: Whether the server is in read-only mode
+        db_cluster_snapshot_identifier: Identifier for the DB cluster snapshot
+        db_cluster_identifier: Identifier of the DB cluster to snapshot
+        tags: Optional list of tags to apply to the snapshot
+
+    Returns:
+        Response dictionary with status and snapshot details
+    """
+    if readonly:
+        return {
+            "message": "[READ-ONLY MODE] Snapshot creation simulated. "
+            f"Would have created snapshot {db_cluster_snapshot_identifier} "
+            f"from DB cluster {db_cluster_identifier}",
+            "simulated": True,
+        }
+
+    try:
+        kwargs = {
+            "DBClusterSnapshotIdentifier": db_cluster_snapshot_identifier,
+            "DBClusterIdentifier": db_cluster_identifier,
+        }
+        
+        if tags:
+            # Format tags for AWS API
+            aws_tags = []
+            for tag_item in tags:
+                for key, value in tag_item.items():
+                    aws_tags.append({"Key": key, "Value": value})
+            kwargs["Tags"] = aws_tags
+        
+        response = rds_client.create_db_cluster_snapshot(**kwargs)
+        
+        # Format the response
+        formatted_snapshot = {
+            "snapshot_id": response.get("DBClusterSnapshot", {}).get("DBClusterSnapshotIdentifier"),
+            "cluster_id": response.get("DBClusterSnapshot", {}).get("DBClusterIdentifier"),
+            "status": response.get("DBClusterSnapshot", {}).get("Status"),
+            "creation_time": response.get("DBClusterSnapshot", {}).get("SnapshotCreateTime"),
+            "engine": response.get("DBClusterSnapshot", {}).get("Engine"),
+            "engine_version": response.get("DBClusterSnapshot", {}).get("EngineVersion"),
+        }
+        
+        return {
+            "message": f"Successfully created DB cluster snapshot {db_cluster_snapshot_identifier}",
+            "formatted_snapshot": formatted_snapshot,
+            "DBClusterSnapshot": response.get("DBClusterSnapshot"),
+        }
+    except Exception as e:
+        logger.error(f"Error creating DB cluster snapshot: {e}")
+        return {"error": str(e)}
+
+
+async def restore_db_cluster_from_snapshot(
+    ctx: Context,
+    rds_client,
+    readonly: bool,
+    db_cluster_identifier: str,
+    snapshot_identifier: str,
+    engine: str,
+    vpc_security_group_ids: Optional[List[str]] = None,
+    db_subnet_group_name: Optional[str] = None,
+    engine_version: Optional[str] = None,
+    port: Optional[int] = None,
+    availability_zones: Optional[List[str]] = None,
+    tags: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    """Creates a new RDS DB cluster from a DB cluster snapshot.
+
+    Args:
+        ctx: MCP context
+        rds_client: Boto3 RDS client
+        readonly: Whether the server is in read-only mode
+        db_cluster_identifier: Identifier for the new DB cluster
+        snapshot_identifier: Identifier of the DB cluster snapshot to restore from
+        engine: Database engine to use
+        vpc_security_group_ids: Optional list of VPC security group IDs
+        db_subnet_group_name: Optional DB subnet group name
+        engine_version: Optional engine version
+        port: Optional port number
+        availability_zones: Optional list of availability zones
+        tags: Optional list of tags to apply to the new cluster
+
+    Returns:
+        Response dictionary with status and cluster details
+    """
+    if readonly:
+        return {
+            "message": "[READ-ONLY MODE] Cluster restoration simulated. "
+            f"Would have restored cluster {db_cluster_identifier} "
+            f"from snapshot {snapshot_identifier}",
+            "simulated": True,
+        }
+
+    try:
+        kwargs = {
+            "DBClusterIdentifier": db_cluster_identifier,
+            "SnapshotIdentifier": snapshot_identifier,
+            "Engine": engine,
+        }
+        
+        # Add optional parameters if provided
+        if vpc_security_group_ids:
+            kwargs["VpcSecurityGroupIds"] = vpc_security_group_ids
+        if db_subnet_group_name:
+            kwargs["DBSubnetGroupName"] = db_subnet_group_name
+        if engine_version:
+            kwargs["EngineVersion"] = engine_version
+        if port:
+            kwargs["Port"] = port
+        if availability_zones:
+            kwargs["AvailabilityZones"] = availability_zones
+        if tags:
+            # Format tags for AWS API
+            aws_tags = []
+            for tag_item in tags:
+                for key, value in tag_item.items():
+                    aws_tags.append({"Key": key, "Value": value})
+            kwargs["Tags"] = aws_tags
+        
+        response = rds_client.restore_db_cluster_from_snapshot(**kwargs)
+        
+        # Format the response
+        formatted_cluster = {
+            "cluster_id": response.get("DBCluster", {}).get("DBClusterIdentifier"),
+            "status": response.get("DBCluster", {}).get("Status"),
+            "engine": response.get("DBCluster", {}).get("Engine"),
+            "engine_version": response.get("DBCluster", {}).get("EngineVersion"),
+        }
+        
+        return {
+            "message": f"Successfully restored DB cluster {db_cluster_identifier} from snapshot {snapshot_identifier}",
+            "formatted_cluster": formatted_cluster,
+            "DBCluster": response.get("DBCluster"),
+        }
+    except Exception as e:
+        logger.error(f"Error restoring DB cluster from snapshot: {e}")
+        return {"error": str(e)}
+
+
+async def restore_db_cluster_to_point_in_time(
+    ctx: Context,
+    rds_client,
+    readonly: bool,
+    db_cluster_identifier: str,
+    source_db_cluster_identifier: str,
+    restore_to_time: Optional[str] = None,
+    use_latest_restorable_time: Optional[bool] = None,
+    port: Optional[int] = None,
+    db_subnet_group_name: Optional[str] = None,
+    vpc_security_group_ids: Optional[List[str]] = None,
+    tags: Optional[List[Dict[str, str]]] = None,
+) -> Dict[str, Any]:
+    """Restores a DB cluster to a specific point in time.
+
+    Args:
+        ctx: MCP context
+        rds_client: Boto3 RDS client
+        readonly: Whether the server is in read-only mode
+        db_cluster_identifier: Identifier for the new DB cluster
+        source_db_cluster_identifier: Identifier of the source DB cluster
+        restore_to_time: Optional timestamp to restore to (format: YYYY-MM-DDTHH:MM:SSZ)
+        use_latest_restorable_time: Optional flag to use the latest restorable time
+        port: Optional port number
+        db_subnet_group_name: Optional DB subnet group name
+        vpc_security_group_ids: Optional list of VPC security group IDs
+        tags: Optional list of tags to apply to the new cluster
+
+    Returns:
+        Response dictionary with status and cluster details
+    """
+    if readonly:
+        return {
+            "message": "[READ-ONLY MODE] Point-in-time restoration simulated. "
+            f"Would have restored cluster {db_cluster_identifier} "
+            f"from source cluster {source_db_cluster_identifier}",
+            "simulated": True,
+        }
+
+    # Validate that either restore_to_time or use_latest_restorable_time is provided
+    if not restore_to_time and not use_latest_restorable_time:
+        return {
+            "error": "Either restore_to_time or use_latest_restorable_time must be provided"
+        }
+
+    try:
+        kwargs = {
+            "DBClusterIdentifier": db_cluster_identifier,
+            "SourceDBClusterIdentifier": source_db_cluster_identifier,
+        }
+        
+        # Add optional parameters if provided
+        if restore_to_time:
+            kwargs["RestoreToTime"] = restore_to_time
+        if use_latest_restorable_time is not None:
+            kwargs["UseLatestRestorableTime"] = use_latest_restorable_time
+        if port:
+            kwargs["Port"] = port
+        if db_subnet_group_name:
+            kwargs["DBSubnetGroupName"] = db_subnet_group_name
+        if vpc_security_group_ids:
+            kwargs["VpcSecurityGroupIds"] = vpc_security_group_ids
+        if tags:
+            # Format tags for AWS API
+            aws_tags = []
+            for tag_item in tags:
+                for key, value in tag_item.items():
+                    aws_tags.append({"Key": key, "Value": value})
+            kwargs["Tags"] = aws_tags
+        
+        response = rds_client.restore_db_cluster_to_point_in_time(**kwargs)
+        
+        # Format the response
+        formatted_cluster = {
+            "cluster_id": response.get("DBCluster", {}).get("DBClusterIdentifier"),
+            "status": response.get("DBCluster", {}).get("Status"),
+            "engine": response.get("DBCluster", {}).get("Engine"),
+            "engine_version": response.get("DBCluster", {}).get("EngineVersion"),
+        }
+        
+        return {
+            "message": f"Successfully restored DB cluster {db_cluster_identifier} to point in time",
+            "formatted_cluster": formatted_cluster,
+            "DBCluster": response.get("DBCluster"),
+        }
+    except Exception as e:
+        logger.error(f"Error restoring DB cluster to point in time: {e}")
+        return {"error": str(e)}
+
+
+async def delete_db_cluster_snapshot(
+    ctx: Context,
+    rds_client,
+    readonly: bool,
+    db_cluster_snapshot_identifier: str,
+    confirmation_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Deletes a DB cluster snapshot.
+
+    Args:
+        ctx: MCP context
+        rds_client: Boto3 RDS client
+        readonly: Whether the server is in read-only mode
+        db_cluster_snapshot_identifier: Identifier of the DB cluster snapshot to delete
+        confirmation_token: Optional confirmation token for destructive operation
+
+    Returns:
+        Response dictionary with status and snapshot details
+    """
+    if readonly:
+        return {
+            "message": "[READ-ONLY MODE] Snapshot deletion simulated. "
+            f"Would have deleted snapshot {db_cluster_snapshot_identifier}",
+            "simulated": True,
+        }
+
+    # If no confirmation token provided, request confirmation
+    if not confirmation_token:
+        # Generate a random token for confirmation
+        token = secrets.token_hex(8)
+        
+        return {
+            "requires_confirmation": True,
+            "warning": f"You are about to delete snapshot {db_cluster_snapshot_identifier}. This operation cannot be undone.",
+            "impact": "Deleting this snapshot will permanently remove it and prevent any future restore operations using this snapshot.",
+            "confirmation_token": token,
+            "message": f"To confirm deletion, please provide this token as confirmation_token: {token}",
+        }
+    
+    try:
+        response = rds_client.delete_db_cluster_snapshot(
+            DBClusterSnapshotIdentifier=db_cluster_snapshot_identifier
+        )
+        
+        # Format the response
+        formatted_snapshot = {
+            "snapshot_id": response.get("DBClusterSnapshot", {}).get("DBClusterSnapshotIdentifier"),
+            "cluster_id": response.get("DBClusterSnapshot", {}).get("DBClusterIdentifier"),
+            "status": response.get("DBClusterSnapshot", {}).get("Status"),
+            "deletion_time": response.get("DBClusterSnapshot", {}).get("SnapshotCreateTime"),
+        }
+        
+        return {
+            "message": f"Successfully deleted DB cluster snapshot {db_cluster_snapshot_identifier}",
+            "formatted_snapshot": formatted_snapshot,
+            "DBClusterSnapshot": response.get("DBClusterSnapshot"),
+        }
+    except Exception as e:
+        logger.error(f"Error deleting DB cluster snapshot: {e}")
+        return {"error": str(e)}
+
+
+async def get_cluster_backups_resource(
+    db_cluster_identifier: str,
+    rds_client,
+) -> str:
+    """Get all backups for a specific DB cluster.
+
+    Args:
+        db_cluster_identifier: Identifier of the DB cluster
+        rds_client: Boto3 RDS client
+
+    Returns:
+        JSON string with backup information
+    """
+    try:
+        # Get automated backups
+        automated_backups = []
+        try:
+            auto_backups_response = rds_client.describe_db_cluster_automated_backups(
+                DBClusterIdentifier=db_cluster_identifier
+            )
+            
+            for backup in auto_backups_response.get("DBClusterAutomatedBackups", []):
+                automated_backups.append(AutomatedBackupModel(
+                    backup_id=backup.get("DBClusterAutomatedBackupArn"),
+                    cluster_id=backup.get("DBClusterIdentifier"),
+                    earliest_time=backup.get("RestoreWindow", {}).get("EarliestTime"),
+                    latest_time=backup.get("RestoreWindow", {}).get("LatestTime"),
+                    status=backup.get("Status"),
+                    engine=backup.get("Engine"),
+                    engine_version=backup.get("EngineVersion"),
+                    resource_uri=f"aws-rds://db-cluster/{db_cluster_identifier}/backups",
+                ))
+        except Exception as e:
+            logger.error(f"Error fetching automated backups for cluster {db_cluster_identifier}: {e}")
+        
+        # Get snapshots
+        snapshots = []
+        try:
+            snapshots_response = rds_client.describe_db_cluster_snapshots(
+                DBClusterIdentifier=db_cluster_identifier
+            )
+            
+            for snapshot in snapshots_response.get("DBClusterSnapshots", []):
+                # Convert tags from AWS format to dict
+                tags = {}
+                for tag in snapshot.get("TagList", []):
+                    tags[tag.get("Key")] = tag.get("Value")
+                
+                snapshots.append(SnapshotModel(
+                    snapshot_id=snapshot.get("DBClusterSnapshotIdentifier"),
+                    cluster_id=snapshot.get("DBClusterIdentifier"),
+                    creation_time=snapshot.get("SnapshotCreateTime"),
+                    status=snapshot.get("Status"),
+                    engine=snapshot.get("Engine"),
+                    engine_version=snapshot.get("EngineVersion"),
+                    port=snapshot.get("Port"),
+                    vpc_id=snapshot.get("VpcId"),
+                    tags=tags,
+                    resource_uri=f"aws-rds://db-cluster/{db_cluster_identifier}/backups",
+                ))
+        except Exception as e:
+            logger.error(f"Error fetching snapshots for cluster {db_cluster_identifier}: {e}")
+        
+        # Create the combined backup list model
+        backup_list = BackupListModel(
+            snapshots=snapshots,
+            automated_backups=automated_backups,
+            count=len(snapshots) + len(automated_backups),
+            resource_uri=f"aws-rds://db-cluster/{db_cluster_identifier}/backups",
+        )
+        
+        # Convert to JSON
+        return json.dumps(backup_list.model_dump(), default=str)
+    
+    except Exception as e:
+        logger.error(f"Error getting backups for cluster {db_cluster_identifier}: {e}")
+        error_response = {
+            "error": str(e),
+            "cluster_id": db_cluster_identifier,
+            "resource_uri": f"aws-rds://db-cluster/{db_cluster_identifier}/backups",
+        }
+        return json.dumps(error_response)
+
+
+async def get_all_cluster_backups_resource(
+    rds_client,
+) -> str:
+    """Get all backups across all DB clusters.
+
+    Args:
+        rds_client: Boto3 RDS client
+
+    Returns:
+        JSON string with backup information for all clusters
+    """
+    try:
+        # Get all clusters first
+        clusters_response = rds_client.describe_db_clusters()
+        all_snapshots = []
+        all_automated_backups = []
+        
+        # For each cluster, get its backups
+        for cluster in clusters_response.get("DBClusters", []):
+            cluster_id = cluster.get("DBClusterIdentifier")
+            
+            # Get automated backups
+            try:
+                auto_backups_response = rds_client.describe_db_cluster_automated_backups()
+                
+                for backup in auto_backups_response.get("DBClusterAutomatedBackups", []):
+                    if backup.get("DBClusterIdentifier") == cluster_id:
+                        all_automated_backups.append(AutomatedBackupModel(
+                            backup_id=backup.get("DBClusterAutomatedBackupArn"),
+                            cluster_id=backup.get("DBClusterIdentifier"),
+                            earliest_time=backup.get("RestoreWindow", {}).get("EarliestTime"),
+                            latest_time=backup.get("RestoreWindow", {}).get("LatestTime"),
+                            status=backup.get("Status"),
+                            engine=backup.get("Engine"),
+                            engine_version=backup.get("EngineVersion"),
+                            resource_uri=f"aws-rds://db-cluster/backups",
+                        ))
+            except Exception as e:
+                logger.error(f"Error fetching automated backups for cluster {cluster_id}: {e}")
+            
+            # Get snapshots
+            try:
+                snapshots_response = rds_client.describe_db_cluster_snapshots(
+                    DBClusterIdentifier=cluster_id
+                )
+                
+                for snapshot in snapshots_response.get("DBClusterSnapshots", []):
+                    # Convert tags from AWS format to dict
+                    tags = {}
+                    for tag in snapshot.get("TagList", []):
+                        tags[tag.get("Key")] = tag.get("Value")
+                    
+                    all_snapshots.append(SnapshotModel(
+                        snapshot_id=snapshot.get("DBClusterSnapshotIdentifier"),
+                        cluster_id=snapshot.get("DBClusterIdentifier"),
+                        creation_time=snapshot.get("SnapshotCreateTime"),
+                        status=snapshot.get("Status"),
+                        engine=snapshot.get("Engine"),
+                        engine_version=snapshot.get("EngineVersion"),
+                        port=snapshot.get("Port"),
+                        vpc_id=snapshot.get("VpcId"),
+                        tags=tags,
+                        resource_uri=f"aws-rds://db-cluster/backups",
+                    ))
+            except Exception as e:
+                logger.error(f"Error fetching snapshots for cluster {cluster_id}: {e}")
+        
+        # Create the combined backup list model
+        backup_list = BackupListModel(
+            snapshots=all_snapshots,
+            automated_backups=all_automated_backups,
+            count=len(all_snapshots) + len(all_automated_backups),
+            resource_uri=f"aws-rds://db-cluster/backups",
+        )
+        
+        # Convert to JSON
+        return json.dumps(backup_list.model_dump(), default=str)
+    
+    except Exception as e:
+        logger.error(f"Error getting backups for all clusters: {e}")
+        error_response = {
+            "error": str(e),
+            "resource_uri": f"aws-rds://db-cluster/backups",
+        }
+        return json.dumps(error_response)
+
+
+async def get_all_instance_backups_resource(
+    rds_client,
+) -> str:
+    """Get all backups across all DB instances.
+
+    Args:
+        rds_client: Boto3 RDS client
+
+    Returns:
+        JSON string with backup information for all instances
+    """
+    try:
+        # Get all instances first
+        instances_response = rds_client.describe_db_instances()
+        all_snapshots = []
+        all_automated_backups = []
+        
+        # For each instance, get its backups
+        for instance in instances_response.get("DBInstances", []):
+            instance_id = instance.get("DBInstanceIdentifier")
+            
+            # Get automated backups
+            try:
+                auto_backups_response = rds_client.describe_db_instance_automated_backups()
+                
+                for backup in auto_backups_response.get("DBInstanceAutomatedBackups", []):
+                    if backup.get("DBInstanceIdentifier") == instance_id:
+                        all_automated_backups.append(AutomatedBackupModel(
+                            backup_id=backup.get("DBInstanceAutomatedBackupsArn"),
+                            cluster_id=backup.get("DBInstanceIdentifier"),  # Using instance ID here
+                            earliest_time=backup.get("RestorableTime"),
+                            latest_time=backup.get("LatestRestorableTime"),
+                            status=backup.get("Status"),
+                            engine=backup.get("Engine"),
+                            engine_version=backup.get("EngineVersion"),
+                            resource_uri=f"aws-rds://db-instance/backups",
+                        ))
+            except Exception as e:
+                logger.error(f"Error fetching automated backups for instance {instance_id}: {e}")
+            
+            # Get snapshots
+            try:
+                snapshots_response = rds_client.describe_db_snapshots(
+                    DBInstanceIdentifier=instance_id
+                )
+                
+                for snapshot in snapshots_response.get("DBSnapshots", []):
+                    # Convert tags from AWS format to dict
+                    tags = {}
+                    for tag in snapshot.get("TagList", []):
+                        tags[tag.get("Key")] = tag.get("Value")
+                    
+                    all_snapshots.append(SnapshotModel(
+                        snapshot_id=snapshot.get("DBSnapshotIdentifier"),
+                        cluster_id=snapshot.get("DBInstanceIdentifier"),  # Using instance ID here
+                        creation_time=snapshot.get("SnapshotCreateTime"),
+                        status=snapshot.get("Status"),
+                        engine=snapshot.get("Engine"),
+                        engine_version=snapshot.get("EngineVersion"),
+                        port=snapshot.get("Port"),
+                        vpc_id=snapshot.get("VpcId"),
+                        tags=tags,
+                        resource_uri=f"aws-rds://db-instance/backups",
+                    ))
+            except Exception as e:
+                logger.error(f"Error fetching snapshots for instance {instance_id}: {e}")
+        
+        # Create the combined backup list model
+        backup_list = BackupListModel(
+            snapshots=all_snapshots,
+            automated_backups=all_automated_backups,
+            count=len(all_snapshots) + len(all_automated_backups),
+            resource_uri=f"aws-rds://db-instance/backups",
+        )
+        
+        # Convert to JSON
+        return json.dumps(backup_list.model_dump(), default=str)
+    
+    except Exception as e:
+        logger.error(f"Error getting backups for all instances: {e}")
+        error_response = {
+            "error": str(e),
+            "resource_uri": f"aws-rds://db-instance/backups",
+        }
+        return json.dumps(error_response)
+
+
+async def get_instance_backups_resource(
+    db_instance_identifier: str,
+    rds_client,
+) -> str:
+    """Get all backups for a specific DB instance.
+
+    Args:
+        db_instance_identifier: Identifier of the DB instance
+        rds_client: Boto3 RDS client
+
+    Returns:
+        JSON string with backup information
+    """
+    try:
+        # Get automated backups
+        automated_backups = []
+        try:
+            auto_backups_response = rds_client.describe_db_instance_automated_backups(
+                DBInstanceIdentifier=db_instance_identifier
+            )
+            
+            for backup in auto_backups_response.get("DBInstanceAutomatedBackups", []):
+                automated_backups.append(AutomatedBackupModel(
+                    backup_id=backup.get("DBInstanceAutomatedBackupsArn"),
+                    cluster_id=backup.get("DBInstanceIdentifier"),  # Using instance ID here since this is instance backup
+                    earliest_time=backup.get("RestorableTime"),
+                    latest_time=backup.get("LatestRestorableTime"),
+                    status=backup.get("Status"),
+                    engine=backup.get("Engine"),
+                    engine_version=backup.get("EngineVersion"),
+                    resource_uri=f"aws-rds://db-instance/{db_instance_identifier}/backups",
+                ))
+        except Exception as e:
+            logger.error(f"Error fetching automated backups for instance {db_instance_identifier}: {e}")
+        
+        # Get snapshots
+        snapshots = []
+        try:
+            snapshots_response = rds_client.describe_db_snapshots(
+                DBInstanceIdentifier=db_instance_identifier
+            )
+            
+            for snapshot in snapshots_response.get("DBSnapshots", []):
+                # Convert tags from AWS format to dict
+                tags = {}
+                for tag in snapshot.get("TagList", []):
+                    tags[tag.get("Key")] = tag.get("Value")
+                
+                snapshots.append(SnapshotModel(
+                    snapshot_id=snapshot.get("DBSnapshotIdentifier"),
+                    cluster_id=snapshot.get("DBInstanceIdentifier"),  # Using instance ID here
+                    creation_time=snapshot.get("SnapshotCreateTime"),
+                    status=snapshot.get("Status"),
+                    engine=snapshot.get("Engine"),
+                    engine_version=snapshot.get("EngineVersion"),
+                    port=snapshot.get("Port"),
+                    vpc_id=snapshot.get("VpcId"),
+                    tags=tags,
+                    resource_uri=f"aws-rds://db-instance/{db_instance_identifier}/backups",
+                ))
+        except Exception as e:
+            logger.error(f"Error fetching snapshots for instance {db_instance_identifier}: {e}")
+        
+        # Create the combined backup list model
+        backup_list = BackupListModel(
+            snapshots=snapshots,
+            automated_backups=automated_backups,
+            count=len(snapshots) + len(automated_backups),
+            resource_uri=f"aws-rds://db-instance/{db_instance_identifier}/backups",
+        )
+        
+        # Convert to JSON
+        return json.dumps(backup_list.model_dump(), default=str)
+    
+    except Exception as e:
+        logger.error(f"Error getting backups for instance {db_instance_identifier}: {e}")
+        error_response = {
+            "error": str(e),
+            "instance_id": db_instance_identifier,
+            "resource_uri": f"aws-rds://db-instance/{db_instance_identifier}/backups",
+        }
+        return json.dumps(error_response)

--- a/awslabs/rds_management_mcp_server/models.py
+++ b/awslabs/rds_management_mcp_server/models.py
@@ -149,3 +149,41 @@ class InstanceListModel(BaseModel):
     )
     count: int = Field(description='Total number of DB instances')
     resource_uri: str = Field(description='The resource URI for the DB instances')
+
+
+class SnapshotModel(BaseModel):
+    """DB Cluster Snapshot model."""
+    
+    snapshot_id: str = Field(description='The identifier for the DB cluster snapshot')
+    cluster_id: str = Field(description='The identifier of the DB cluster')
+    creation_time: datetime = Field(description='The time when the snapshot was taken')
+    status: str = Field(description='The status of the DB cluster snapshot')
+    engine: str = Field(description='The database engine')
+    engine_version: str = Field(description='The version of the database engine')
+    port: Optional[int] = Field(None, description='The port that the DB cluster was listening on')
+    vpc_id: Optional[str] = Field(None, description='The VPC ID associated with the DB cluster snapshot')
+    tags: Dict[str, str] = Field(default_factory=dict, description='A list of tags')
+    resource_uri: Optional[str] = Field(None, description='The resource URI for this snapshot')
+
+
+class AutomatedBackupModel(BaseModel):
+    """DB Cluster Automated Backup model."""
+    
+    backup_id: str = Field(description='The identifier for the automated backup')
+    cluster_id: str = Field(description='The identifier of the DB cluster')
+    earliest_time: datetime = Field(description='The earliest restorable time')
+    latest_time: datetime = Field(description='The latest restorable time')
+    status: str = Field(description='The status of the automated backup')
+    engine: str = Field(description='The database engine')
+    engine_version: str = Field(description='The version of the database engine')
+    resource_uri: Optional[str] = Field(None, description='The resource URI for this backup')
+
+
+class BackupListModel(BaseModel):
+    """Backup list model including both snapshots and automated backups."""
+    
+    snapshots: List[SnapshotModel] = Field(default_factory=list, description='List of DB cluster snapshots')
+    automated_backups: List[AutomatedBackupModel] = Field(default_factory=list, 
+                                                         description='List of DB cluster automated backups')
+    count: int = Field(description='Total number of backups')
+    resource_uri: str = Field(description='The resource URI for the backups')

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -1,0 +1,441 @@
+# Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for RDS Management MCP Server backup module."""
+
+import asyncio
+import json
+import secrets
+import pytest
+from datetime import datetime, timezone
+from unittest.mock import patch, MagicMock, AsyncMock
+from botocore.exceptions import ClientError
+from awslabs.rds_management_mcp_server import backup
+
+
+@pytest.fixture
+def sample_snapshot():
+    """Return a sample DB cluster snapshot response."""
+    return {
+        'DBClusterSnapshotIdentifier': 'test-snapshot',
+        'DBClusterIdentifier': 'test-db-cluster',
+        'SnapshotCreateTime': datetime(2023, 6, 15, 12, 0, 0, tzinfo=timezone.utc),
+        'Status': 'available',
+        'Engine': 'aurora-mysql',
+        'EngineVersion': '5.7.mysql_aurora.2.10.2',
+        'Port': 3306,
+        'VpcId': 'vpc-12345678',
+        'DBClusterSnapshotArn': 'arn:aws:rds:us-east-1:123456789012:cluster-snapshot:test-snapshot',
+        'TagList': [
+            {
+                'Key': 'Environment',
+                'Value': 'Test'
+            }
+        ]
+    }
+
+
+@pytest.fixture
+def sample_automated_backup():
+    """Return a sample DB cluster automated backup response."""
+    return {
+        'DBClusterIdentifier': 'test-db-cluster',
+        'DBClusterAutomatedBackupArn': 'arn:aws:rds:us-east-1:123456789012:cluster-backup:test-backup',
+        'Status': 'available',
+        'Engine': 'aurora-mysql',
+        'EngineVersion': '5.7.mysql_aurora.2.10.2',
+        'RestoreWindow': {
+            'EarliestTime': datetime(2023, 6, 10, 12, 0, 0, tzinfo=timezone.utc),
+            'LatestTime': datetime(2023, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        }
+    }
+
+
+@pytest.mark.asyncio
+class TestCreateDbClusterSnapshot:
+    """Tests for create_db_cluster_snapshot function."""
+
+    async def test_create_snapshot_success(self, context, mock_rds_client, sample_snapshot):
+        """Test successful creation of cluster snapshot."""
+        # Set up the mock
+        mock_rds_client.create_db_cluster_snapshot.return_value = {
+            'DBClusterSnapshot': sample_snapshot
+        }
+
+        # Execute the function
+        result = await backup.create_db_cluster_snapshot(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=False,
+            db_cluster_snapshot_identifier='test-snapshot',
+            db_cluster_identifier='test-db-cluster',
+            tags=[{'Key': 'Environment', 'Value': 'Test'}]
+        )
+
+        # Assert the result
+        assert 'message' in result
+        assert 'Successfully created DB cluster snapshot' in result['message']
+        assert 'formatted_snapshot' in result
+        assert result['formatted_snapshot']['snapshot_id'] == 'test-snapshot'
+        assert result['formatted_snapshot']['cluster_id'] == 'test-db-cluster'
+        assert 'DBClusterSnapshot' in result
+
+        # Assert the API call
+        mock_rds_client.create_db_cluster_snapshot.assert_called_once()
+        args, kwargs = mock_rds_client.create_db_cluster_snapshot.call_args
+        assert kwargs['DBClusterSnapshotIdentifier'] == 'test-snapshot'
+        assert kwargs['DBClusterIdentifier'] == 'test-db-cluster'
+        assert 'Tags' in kwargs
+
+    async def test_create_snapshot_readonly(self, context, mock_rds_client):
+        """Test creation of cluster snapshot in readonly mode."""
+        # Execute the function in readonly mode
+        result = await backup.create_db_cluster_snapshot(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=True,
+            db_cluster_snapshot_identifier='test-snapshot',
+            db_cluster_identifier='test-db-cluster'
+        )
+
+        # Assert the result indicates read-only simulation
+        assert 'message' in result
+        assert '[READ-ONLY MODE]' in result['message']
+        assert 'simulated' in result and result['simulated'] is True
+
+        # Assert no API calls were made
+        mock_rds_client.create_db_cluster_snapshot.assert_not_called()
+
+    async def test_create_snapshot_error(self, context, mock_rds_client):
+        """Test error handling for snapshot creation."""
+        # Set up the mock to raise an error
+        error_response = {'Error': {'Code': 'DBClusterNotFoundFault', 'Message': 'DB cluster not found'}}
+        mock_rds_client.create_db_cluster_snapshot.side_effect = ClientError(error_response, 'CreateDBClusterSnapshot')
+
+        # Execute the function
+        result = await backup.create_db_cluster_snapshot(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=False,
+            db_cluster_snapshot_identifier='test-snapshot',
+            db_cluster_identifier='non-existent-cluster'
+        )
+
+        # Assert the error is handled
+        assert 'error' in result
+        assert 'DB cluster not found' in result['error']
+
+
+@pytest.mark.asyncio
+class TestRestoreDbClusterFromSnapshot:
+    """Tests for restore_db_cluster_from_snapshot function."""
+
+    async def test_restore_from_snapshot_success(self, context, mock_rds_client, sample_db_cluster):
+        """Test successful restore from snapshot."""
+        # Set up the mock
+        mock_rds_client.restore_db_cluster_from_snapshot.return_value = {
+            'DBCluster': sample_db_cluster
+        }
+
+        # Execute the function
+        result = await backup.restore_db_cluster_from_snapshot(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=False,
+            db_cluster_identifier='restored-cluster',
+            snapshot_identifier='test-snapshot',
+            engine='aurora-mysql',
+            vpc_security_group_ids=['sg-12345678'],
+            engine_version='5.7.mysql_aurora.2.10.2'
+        )
+
+        # Assert the result
+        assert 'message' in result
+        assert 'Successfully restored DB cluster' in result['message']
+        assert 'formatted_cluster' in result
+        assert result['formatted_cluster']['cluster_id'] == 'test-db-cluster'
+        assert 'DBCluster' in result
+
+        # Assert the API call
+        mock_rds_client.restore_db_cluster_from_snapshot.assert_called_once()
+        args, kwargs = mock_rds_client.restore_db_cluster_from_snapshot.call_args
+        assert kwargs['DBClusterIdentifier'] == 'restored-cluster'
+        assert kwargs['SnapshotIdentifier'] == 'test-snapshot'
+        assert kwargs['Engine'] == 'aurora-mysql'
+        assert kwargs['VpcSecurityGroupIds'] == ['sg-12345678']
+        assert kwargs['EngineVersion'] == '5.7.mysql_aurora.2.10.2'
+
+    async def test_restore_from_snapshot_readonly(self, context, mock_rds_client):
+        """Test restore from snapshot in readonly mode."""
+        # Execute the function in readonly mode
+        result = await backup.restore_db_cluster_from_snapshot(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=True,
+            db_cluster_identifier='restored-cluster',
+            snapshot_identifier='test-snapshot',
+            engine='aurora-mysql'
+        )
+
+        # Assert the result indicates read-only simulation
+        assert 'message' in result
+        assert '[READ-ONLY MODE]' in result['message']
+        assert 'simulated' in result and result['simulated'] is True
+
+        # Assert no API calls were made
+        mock_rds_client.restore_db_cluster_from_snapshot.assert_not_called()
+
+    async def test_restore_from_snapshot_error(self, context, mock_rds_client):
+        """Test error handling for snapshot restore."""
+        # Set up the mock to raise an error
+        error_response = {'Error': {'Code': 'DBSnapshotNotFoundFault', 'Message': 'DB snapshot not found'}}
+        mock_rds_client.restore_db_cluster_from_snapshot.side_effect = ClientError(error_response, 'RestoreDBClusterFromSnapshot')
+
+        # Execute the function
+        result = await backup.restore_db_cluster_from_snapshot(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=False,
+            db_cluster_identifier='restored-cluster',
+            snapshot_identifier='non-existent-snapshot',
+            engine='aurora-mysql'
+        )
+
+        # Assert the error is handled
+        assert 'error' in result
+        assert 'DB snapshot not found' in result['error']
+
+
+@pytest.mark.asyncio
+class TestRestoreDbClusterToPointInTime:
+    """Tests for restore_db_cluster_to_point_in_time function."""
+
+    async def test_restore_to_point_in_time_success(self, context, mock_rds_client, sample_db_cluster):
+        """Test successful point-in-time restore."""
+        # Set up the mock
+        mock_rds_client.restore_db_cluster_to_point_in_time.return_value = {
+            'DBCluster': sample_db_cluster
+        }
+        
+        restore_time = '2023-06-15T12:00:00Z'
+
+        # Execute the function
+        result = await backup.restore_db_cluster_to_point_in_time(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=False,
+            db_cluster_identifier='restored-cluster',
+            source_db_cluster_identifier='test-db-cluster',
+            restore_to_time=restore_time,
+            vpc_security_group_ids=['sg-12345678']
+        )
+
+        # Assert the result
+        assert 'message' in result
+        assert 'Successfully restored DB cluster' in result['message']
+        assert 'formatted_cluster' in result
+        assert result['formatted_cluster']['cluster_id'] == 'test-db-cluster'
+        assert 'DBCluster' in result
+
+        # Assert the API call
+        mock_rds_client.restore_db_cluster_to_point_in_time.assert_called_once()
+        args, kwargs = mock_rds_client.restore_db_cluster_to_point_in_time.call_args
+        assert kwargs['DBClusterIdentifier'] == 'restored-cluster'
+        assert kwargs['SourceDBClusterIdentifier'] == 'test-db-cluster'
+        assert kwargs['RestoreToTime'] == restore_time
+        assert kwargs['VpcSecurityGroupIds'] == ['sg-12345678']
+
+    async def test_restore_to_latest_time_success(self, context, mock_rds_client, sample_db_cluster):
+        """Test successful restore to latest time."""
+        # Set up the mock
+        mock_rds_client.restore_db_cluster_to_point_in_time.return_value = {
+            'DBCluster': sample_db_cluster
+        }
+
+        # Execute the function
+        result = await backup.restore_db_cluster_to_point_in_time(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=False,
+            db_cluster_identifier='restored-cluster',
+            source_db_cluster_identifier='test-db-cluster',
+            use_latest_restorable_time=True
+        )
+
+        # Assert the result
+        assert 'message' in result
+        assert 'Successfully restored DB cluster' in result['message']
+        
+        # Assert the API call
+        mock_rds_client.restore_db_cluster_to_point_in_time.assert_called_once()
+        args, kwargs = mock_rds_client.restore_db_cluster_to_point_in_time.call_args
+        assert kwargs['UseLatestRestorableTime'] is True
+
+    async def test_restore_to_point_in_time_missing_time_params(self, context, mock_rds_client):
+        """Test error when neither time nor latest flag is provided."""
+        # Execute the function with missing parameters
+        result = await backup.restore_db_cluster_to_point_in_time(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=False,
+            db_cluster_identifier='restored-cluster',
+            source_db_cluster_identifier='test-db-cluster'
+        )
+
+        # Assert the appropriate error is returned
+        assert 'error' in result
+        assert 'Either restore_to_time or use_latest_restorable_time must be provided' in result['error']
+
+        # Assert no API calls were made
+        mock_rds_client.restore_db_cluster_to_point_in_time.assert_not_called()
+
+
+@pytest.mark.asyncio
+class TestDeleteDbClusterSnapshot:
+    """Tests for delete_db_cluster_snapshot function."""
+
+    async def test_delete_snapshot_request_confirmation(self, context, mock_rds_client):
+        """Test snapshot deletion confirmation request."""
+        # Mock the secrets.token_hex function to return a predictable token
+        with patch('secrets.token_hex', return_value='abc123'):
+            # Execute the function without a confirmation token
+            result = await backup.delete_db_cluster_snapshot(
+                ctx=context,
+                rds_client=mock_rds_client,
+                readonly=False,
+                db_cluster_snapshot_identifier='test-snapshot'
+            )
+
+            # Assert the confirmation request is returned
+            assert 'requires_confirmation' in result and result['requires_confirmation'] is True
+            assert 'confirmation_token' in result and result['confirmation_token'] == 'abc123'
+            assert 'warning' in result
+            assert 'impact' in result
+            assert 'message' in result
+
+            # Assert no API calls were made
+            mock_rds_client.delete_db_cluster_snapshot.assert_not_called()
+
+    async def test_delete_snapshot_with_confirmation(self, context, mock_rds_client, sample_snapshot):
+        """Test successful snapshot deletion with confirmation token."""
+        # Set up the mock
+        mock_rds_client.delete_db_cluster_snapshot.return_value = {
+            'DBClusterSnapshot': sample_snapshot
+        }
+
+        # Execute the function with a confirmation token
+        result = await backup.delete_db_cluster_snapshot(
+            ctx=context,
+            rds_client=mock_rds_client,
+            readonly=False,
+            db_cluster_snapshot_identifier='test-snapshot',
+            confirmation_token='valid-token'
+        )
+
+        # Assert the result
+        assert 'message' in result
+        assert 'Successfully deleted DB cluster snapshot' in result['message']
+        assert 'formatted_snapshot' in result
+        assert 'DBClusterSnapshot' in result
+
+        # Assert the API call
+        mock_rds_client.delete_db_cluster_snapshot.assert_called_once_with(
+            DBClusterSnapshotIdentifier='test-snapshot'
+        )
+
+
+@pytest.mark.asyncio
+class TestGetClusterBackupsResource:
+    """Tests for get_cluster_backups_resource function."""
+
+    async def test_get_cluster_backups_success(self, mock_rds_client, sample_snapshot, sample_automated_backup):
+        """Test successful retrieval of cluster backups."""
+        # Set up the mocks
+        mock_rds_client.describe_db_cluster_snapshots.return_value = {
+            'DBClusterSnapshots': [sample_snapshot]
+        }
+        mock_rds_client.describe_db_cluster_automated_backups.return_value = {
+            'DBClusterAutomatedBackups': [sample_automated_backup]
+        }
+
+        # Execute the function
+        result = await backup.get_cluster_backups_resource(
+            db_cluster_identifier='test-db-cluster',
+            rds_client=mock_rds_client
+        )
+
+        # Parse the JSON result
+        parsed_result = json.loads(result)
+        
+        # Assert the result structure
+        assert 'snapshots' in parsed_result
+        assert 'automated_backups' in parsed_result
+        assert 'count' in parsed_result
+        assert parsed_result['count'] == 2  # 1 snapshot + 1 automated backup
+        assert 'resource_uri' in parsed_result
+        
+        # Check snapshot details
+        assert len(parsed_result['snapshots']) == 1
+        assert parsed_result['snapshots'][0]['snapshot_id'] == 'test-snapshot'
+        assert parsed_result['snapshots'][0]['cluster_id'] == 'test-db-cluster'
+        
+        # Check automated backup details
+        assert len(parsed_result['automated_backups']) == 1
+        assert parsed_result['automated_backups'][0]['cluster_id'] == 'test-db-cluster'
+        
+        # Assert API calls
+        mock_rds_client.describe_db_cluster_snapshots.assert_called_once_with(
+            DBClusterIdentifier='test-db-cluster'
+        )
+        mock_rds_client.describe_db_cluster_automated_backups.assert_called_once_with(
+            DBClusterIdentifier='test-db-cluster'
+        )
+
+
+@pytest.mark.asyncio
+class TestGetAllClusterBackupsResource:
+    """Tests for get_all_cluster_backups_resource function."""
+
+    async def test_get_all_cluster_backups_success(self, mock_rds_client, sample_db_cluster, sample_snapshot, sample_automated_backup):
+        """Test successful retrieval of all cluster backups."""
+        # Set up the mocks
+        mock_rds_client.describe_db_clusters.return_value = {
+            'DBClusters': [sample_db_cluster]
+        }
+        mock_rds_client.describe_db_cluster_snapshots.return_value = {
+            'DBClusterSnapshots': [sample_snapshot]
+        }
+        mock_rds_client.describe_db_cluster_automated_backups.return_value = {
+            'DBClusterAutomatedBackups': [sample_automated_backup]
+        }
+
+        # Execute the function
+        result = await backup.get_all_cluster_backups_resource(
+            rds_client=mock_rds_client
+        )
+
+        # Parse the JSON result
+        parsed_result = json.loads(result)
+        
+        # Assert the result structure
+        assert 'snapshots' in parsed_result
+        assert 'automated_backups' in parsed_result
+        assert 'count' in parsed_result
+        assert parsed_result['count'] > 0
+        assert 'resource_uri' in parsed_result
+        assert parsed_result['resource_uri'] == 'aws-rds://db-cluster/backups'
+        
+        # Assert API calls
+        mock_rds_client.describe_db_clusters.assert_called_once()
+        mock_rds_client.describe_db_cluster_snapshots.assert_called()


### PR DESCRIPTION
**Tools**     
    - `create_db_cluster_snapshot`: Create a manual snapshot of an Aurora DB cluster
    - `restore_db_cluster_from_snapshot`: Create a new Aurora DB cluster from a DB cluster snapshot
    - `restore_db_cluster_to_point_in_time`: Restore a DB cluster to a specific point in time using automated backups
    - `delete_db_cluster_snapshot `: Delete a DB cluster snapshot
    - `describe_db_cluster_snapshots`: Returns information about DB cluster snapshots

**Resources**
    - `aws-rds://db-cluster/{db_cluster_identifier}/backups`: List all backups including manual snapshot and auto backups for a specific db cluster
    - `aws-rds://db-instance/{db_instance_identifier}/backups`: List of backups including manual snapshot and auto backups for a specific db instance